### PR TITLE
Change the MacOS shortcut to be `ctrl+alt+T` to avoid conflict with already existing one

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Helps to automatically place the non-breaking spaces, correct small typos, repla
 
 ## Features
 
-Select text and press <kbd>command</kbd> + <kbd>alt</kbd> + <kbd>T</kbd> (<kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>T</kbd> on Windows/Linux).
+Select text and press <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>T</kbd>.
 
 
 | before                                                       	| after                                            	|

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       {
         "command": "vscode-typograf.processSelected",
         "key": "ctrl+alt+t",
-        "mac": "cmd+alt+t",
+        "mac": "ctrl+alt+t",
         "when": "editorHasSelection"
       }
     ],


### PR DESCRIPTION
Hey!
Thanks for the extension, really great!

I was wondering if it is possible to change the default MacOS keyboard shortcut from `command+alt+T` to another. This shortcut is already taken by default action (it closes all the documents except the current) and it's very inconvenient to disable and enable extension every now and then.

In this PR, I propose `ctrl+alt+T` cause it seems not to be taken by any standard action in VS Code.
What do you think?